### PR TITLE
Fixed StumbleUpon ShortURL Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 ITPSocialButtons Plugin for Joomla! 
 ==========================
-( Version 2.1 )
+( Version 2.1.1 )
 --------------------------
 
 Changelog
 ---------
+
+Version 2.1.1
+--------
+* Fixed StumbleUpon button
 
 Version 2.1
 --------

--- a/itpsocialbuttons.php
+++ b/itpsocialbuttons.php
@@ -774,6 +774,7 @@ class plgContentITPSocialButtons extends JPlugin {
      */
     private function getContent(&$article, $context){
         
+		$base 	= rawurlencode( $this->getUrl($article, $context) );
         $url    = rawurlencode( $this->getUrl($article, $context) );
         $title  = rawurlencode( $this->getTitle($article, $context) );
         
@@ -805,7 +806,7 @@ class plgContentITPSocialButtons extends JPlugin {
             $html .= $this->getGoogleButton($title, $url);
         }
         if($this->params->get("displaySumbleUpon")) {
-            $html .= $this->getStumbleuponButton($title, $url);
+            $html .= $this->getStumbleuponButton($title, $base);
         }
         if($this->params->get("displayTechnorati")) {
             $html .= $this->getTechnoratiButton($title, $url);            


### PR DESCRIPTION
StumbleUpon gives the following errors with the ShortURL services provided.

goo.gl = Sorry, this isn't eligible to be added to StumbleUpon.
bit.ly = Sorry, we don't accept submissions from this site.
bitly.com = This webpage is not available. Please try another page.
j.mp = Sorry, this isn't eligible to be added to StumbleUpon.
tiny.cc = Sorry, this isn't eligible to be added to StumbleUpon.

This is simple to overcome by disabling StumbleUpon (don't like this idea) or by passing the the original URL instead of the ShortURL to StumbleUpon. The problem is the $url variable gets overwritten if using the ShortURL options before it can be passed but we can fix this by adding 1 line of code and changing the variable StumbleUpon uses.

OPEN itpsocialbuttons.php
FIND ...

private function getContent(&$article, $context){

... ADD AFTER ...

$base = rawurlencode( $this->getUrl($article, $context) );

... FIND ...

$html .= $this->getStumbleuponButton($title, $url);

... REPLACE WITH ...

$html .= $this->getStumbleuponButton($title, $base);

END OF MOD

This sets the $base variable to use the same declaration of the original $url variable and lets the other connection services continue to use the ShortURL

Anyway, thanks for creating the extensions I have been enjoying playing with them.
