### PR TITLE
StumbleUpon ShortURL Issue - Trunk

### DIFF
--- a/itpsocialbuttons.php
+++ b/itpsocialbuttons.php
@@ -774,6 +774,7 @@ class plgContentITPSocialButtons extends JPlugin {
      */
     private function getContent(&$article, $context){
         
+        $base   = rawurlencode( $this->getUrl($article, $context) );
         $url    = rawurlencode( $this->getUrl($article, $context) );
         $title  = rawurlencode( $this->getTitle($article, $context) );
         
@@ -805,7 +806,7 @@ class plgContentITPSocialButtons extends JPlugin {
             $html .= $this->getGoogleButton($title, $url);
         }
         if($this->params->get("displaySumbleUpon")) {
-            $html .= $this->getStumbleuponButton($title, $url);
+            $html .= $this->getStumbleuponButton($title, $base);
         }
         if($this->params->get("displayTechnorati")) {
             $html .= $this->getTechnoratiButton($title, $url);            


### PR DESCRIPTION
StumbleUpon gives the following errors with the ShortURL services provided.

goo.gl = Sorry, this isn't eligible to be added to StumbleUpon.
bit.ly = Sorry, we don't accept submissions from this site.
bitly.com = This webpage is not available. Please try another page.
j.mp = Sorry, this isn't eligible to be added to StumbleUpon.
tiny.cc = Sorry, this isn't eligible to be added to StumbleUpon.

This is simple to overcome by disabling StumbleUpon (don't like this idea) or by passing the original URL instead of the ShortURL to StumbleUpon. The problem is the $url variable gets overwritten if using the ShortURL options before it can be passed but we can fix this by adding 1 line of code and changing the variable StumbleUpon uses.

OPEN itpsocialbuttons.php
FIND ...

<pre><code>    private function getContent(&$article, $context){
        
</code></pre>


... ADD AFTER ...

<pre><code>        
        $base  = rawurlencode( $this->getUrl($article, $context) );
</code></pre>


... FIND ...

<pre><code>            $html .= $this->getStumbleuponButton($title, $url);</code></pre>


... REPLACE WITH ...

<pre><code>            $html .= $this->getStumbleuponButton($title, $base);</code></pre>


END OF MOD

This sets the $base variable to use the same declaration of the original $url variable and lets the other connection services continue to use the ShortURL

Sorry, am still learning how GIT works so not sure how everything works around here o.O
